### PR TITLE
Running tests from file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the "test-runner" extension will be documented in this fi
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## 1.0.4 [2018-12-10]
+
+enhancement
+
+- Added the ability to attempt to run tests from respective file [#6](https://github.com/EricTurf/vscode-test-runner/pull/6)
+
 ## 1.0.3 [2018-11-29]
 
 enhancement

--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ In a test file use the keyboard shortcut `⌥`+`⌘`+`t` and your test will run.
 
 ## Release Notes
 
+## 1.0.4 [2018-11-29]
+
+enhancement
+
+- Added the ability to attempt to run tests from respective file [#6](https://github.com/EricTurf/vscode-test-runner/pull/6)
+
 ## 1.0.3 [2018-11-29]
 
 enhancement

--- a/extension/extension.js
+++ b/extension/extension.js
@@ -1,6 +1,7 @@
 const { window, commands, workspace } = require('vscode');
-const fs = require('fs');
-const path = require('path');
+
+const { version } = require('../package.json');
+const getTestFilePath = require('./get-test-file-path');
 
 const getPackageManager = require('./get-package-manager');
 const getCwd = require('./get-cwd');
@@ -13,17 +14,11 @@ const PKG_COMMANDS = {
   npm: 'npm run',
 };
 
-const terminalTitle = `Jest Test Runner v${getVersion()}`;
+const terminalTitle = `Jest Test Runner v${version}`;
 let previousCwd = '';
 
 function getPkgCommand() {
   return PKG_COMMANDS[packageManager];
-}
-
-function getVersion() {
-  return JSON.parse(
-    fs.readFileSync(path.join(__dirname, '..', 'package.json'), 'utf-8')
-  ).version;
 }
 
 function activate(context) {
@@ -59,12 +54,15 @@ function activate(context) {
     previousCwd = cwd;
 
     const cwdRoot = cwd.split('/').pop();
-
+    /* ${getTestFilePath(filePath).replace(
+        `${cwdRoot}/`,
+        ''
+      )*/
     terminal.show(true);
     terminal.sendText(
-      `${getPkgCommand()} test ${workspace
-        .asRelativePath(window.activeTextEditor.document.uri)
-        .replace(`${cwdRoot}/`, '')}`
+      `${getPkgCommand()} test ${getTestFilePath(
+        workspace.asRelativePath(window.activeTextEditor.document.uri)
+      ).replace(`${cwdRoot}/`, '')}`
     );
   });
 

--- a/extension/extension.js
+++ b/extension/extension.js
@@ -54,10 +54,7 @@ function activate(context) {
     previousCwd = cwd;
 
     const cwdRoot = cwd.split('/').pop();
-    /* ${getTestFilePath(filePath).replace(
-        `${cwdRoot}/`,
-        ''
-      )*/
+   
     terminal.show(true);
     terminal.sendText(
       `${getPkgCommand()} test ${getTestFilePath(

--- a/extension/get-test-file-path.js
+++ b/extension/get-test-file-path.js
@@ -1,0 +1,49 @@
+const { workspace } = require('vscode');
+const fs = require('fs');
+const path = require('path');
+
+module.exports = filePath => {
+  if (filePath.includes('.spec.js') || filePath.includes('.test.js'))
+    return filePath;
+
+  const fileName = filePath.split('/').pop();
+
+  const directory = filePath
+    .split('/')
+    .filter(el => el !== fileName)
+    .join('/');
+
+  const directoryFiles = fs.readdirSync(
+    path.join(workspace.rootPath, directory)
+  );
+
+  let testDir = '';
+
+  if (directoryFiles.includes('tests')) {
+    testDir = 'tests';
+  } else if (directoryFiles.includes('__tests__')) {
+    testDir = '__tests__';
+  } else if (directoryFiles.includes('spec')) {
+    testDir = 'spec';
+  }
+
+  const testDirFiles = fs.readdirSync(
+    path.join(workspace.rootPath, directory, testDir)
+  );
+
+  const testFile = testDirFiles.find(file => {
+    return (
+      fileName.replace('.js', '.spec.js') === file ||
+      fileName.replace('.js', '.test.js') === file
+    );
+  });
+
+  if (testFile) {
+    const filePathParts = filePath.split('/');
+
+    filePathParts.splice(filePathParts.length - 1, 0, testDir);
+
+    console.log(filePathParts);
+    return filePathParts.join('/').replace(fileName, testFile);
+  } else return filePath;
+};

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "test-runner",
   "displayName": "test-runner",
   "description": "Runs test of current file",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "publisher": "ericTurf",
   "engines": {
     "vscode": "^1.28.0"


### PR DESCRIPTION
This pr adds the ability to find and run a test file from the file.

ie: Running the command from `thing.js` will look in the same directory for a `tests`,`__tests__` or `spec` directory. If it matches one, it will look in that directory for a `thing.test.js` or `test.spec.js` file and run it.